### PR TITLE
A support for dmesg from newer kernels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN pipenv sync --system --clear --dev
 COPY . .
 RUN python3 -m pip install --no-cache-dir --disable-pip-version-check --no-deps --editable=.
 RUN prospector --output=pylint
+RUN pytest
 
 FROM base AS runner
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,22 @@
 all: docker
 
-.venv/timestamp: requirements.txt Makefile
-	/usr/bin/virtualenv --python=/usr/bin/python3 .venv
+.venv/timestamp: requirements.txt Makefile Pipfile
+	/usr/bin/python3 -m virtualenv .venv
 	.venv/bin/pip install --upgrade -r requirements.txt
-	.venv/bin/pipenv install
+	.venv/bin/pipenv install --dev
 	touch $@
+
+.venv/bin/c2cciutils-checks: ci/requirements.txt
+	.venv/bin/pip install --upgrade -r ci/requirements.txt
+	touch $@
+
+.PHONY: tests
+tests: .venv/timestamp
+	.venv/bin/pytest
+
+fix: .venv/bin/c2cciutils-checks
+	(source .venv/bin/activate; c2cciutils-checks --fix --check black)
+	(source .venv/bin/activate; c2cciutils-checks --fix --check isort)
 
 .PHONY: docker
 docker:

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,8 @@ pyramid = "==2.0"
 prospector = {version = "==1.5.3", extras = ["with_bandit", "with_mypy"]}
 flake8 = "==3.9.2"
 types-requests = "==2.26.1"
+pytest = "==6.2.5"
+mockito = "==1.3.0"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1c9a4730b94697ce339321a1c343f3c49709ad6f1c22ce3e498bf298c4dd7e98"
+            "sha256": "ca6084b232bd7cd0cbc8b3b742f0dfb5db70d7453588436f6fc55498aebecc15"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -174,7 +174,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.8.2"
         },
         "pyyaml": {
@@ -253,7 +253,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "translationstring": {
@@ -284,16 +284,16 @@
                 "sha256:73aae30359291c14fa3b956f8b5ca31960e420c28c1bec002547fb04928cf89b",
                 "sha256:b64ef5141be559cfade448f044fa45c2260351edcb6a8ef6b7e00c7dcef0c323"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.8.7"
         },
         "websocket-client": {
             "hashes": [
-                "sha256:0133d2f784858e59959ce82ddac316634229da55b498aac311f1620567a710ec",
-                "sha256:8dfb715d8a992f5712fff8c843adae94e22b22a99b2c5e6b0ec4a1a981cc4e0d"
+                "sha256:21861f8645eb5725d1becfe86d7e7ae1a31d98b72556f9d44fcc5100976353cf",
+                "sha256:5d6a25cf0a8e936f473eceb53c4017ca85d91c7bc45c31634b62ec7190f5728e"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.2.1"
+            "version": "==1.2.2"
         },
         "zope.deprecation": {
             "hashes": [
@@ -369,6 +369,14 @@
             "markers": "python_version ~= '3.6'",
             "version": "==2.8.6"
         },
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
         "bandit": {
             "hashes": [
                 "sha256:a81b00b5436e6880fa8ad6799bc830e02032047713cbb143a12939ac67eb756c",
@@ -414,12 +422,19 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.1.24"
         },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
         "isort": {
             "hashes": [
                 "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
                 "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"
             ],
-            "markers": "python_version < '4.0' and python_full_version >= '3.6.1'",
+            "markers": "python_full_version >= '3.6.1' and python_version < '4.0'",
             "version": "==5.10.1"
         },
         "lazy-object-proxy": {
@@ -457,6 +472,14 @@
             ],
             "version": "==0.6.1"
         },
+        "mockito": {
+            "hashes": [
+                "sha256:42acdeb632c27a1b26169995ebec935752f7511ec7d12039ac32909dd6d5a747",
+                "sha256:5d41a5f6ec0b8fc32b6d796480d4849ee5fb0ac75d12f13862f1622684f5f578"
+            ],
+            "index": "pypi",
+            "version": "==1.3.0"
+        },
         "mypy": {
             "hashes": [
                 "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9",
@@ -492,6 +515,14 @@
             ],
             "version": "==0.4.3"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
+        },
         "pbr": {
             "hashes": [
                 "sha256:176e8560eaf61e127817ef93d8a844803abb27a4d4637f0ff3bb783129be2e0a",
@@ -515,6 +546,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==2.4.0"
         },
+        "pluggy": {
+            "hashes": [
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
+        },
         "prospector": {
             "extras": [
                 "with_bandit",
@@ -526,6 +565,14 @@
             ],
             "index": "pypi",
             "version": "==1.5.3"
+        },
+        "py": {
+            "hashes": [
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pycodestyle": {
             "hashes": [
@@ -584,6 +631,22 @@
                 "sha256:57625dcca20140f43731311cd8fd879318bf45a8b0fd17020717a8781714a25a"
             ],
             "version": "==0.6"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.6"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
+                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+            ],
+            "index": "pypi",
+            "version": "==6.2.5"
         },
         "pyyaml": {
             "hashes": [
@@ -673,7 +736,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "types-requests": {

--- a/es_oom_exporter/dmesg.py
+++ b/es_oom_exporter/dmesg.py
@@ -2,20 +2,20 @@ import logging
 import os
 import re
 import subprocess  # nosec
-from typing import List, Optional
+from typing import Dict, Iterable, List, Optional
 
 from es_oom_exporter.kube import Kubernetes
 from es_oom_exporter.message_reader import MessageReader
 from es_oom_exporter.oom import Oom
 
-# Interesting messages in dmesg:
+LOG = logging.getLogger(__name__)
+TIMESTAMP_RE = re.compile(r"\[\s*(\d+\.\d+)\].*")
+
+# Interesting messages in dmesg with old kernels:
 # [21013.577527] Task in /kubepods/burstable/podaf389229-5fc5-4617-ae95-9160d576eb49/3b3d031aca1bab63c359a8aac8c18e373ac90373faf12c69e5225aec01fc9c84 killed as a result of limit of /kubepods/burstable/podaf389229-5fc5-4617-ae95-9160d576eb49  # noqa: E501
 # [21013.577527] Memory cgroup stats for /kubepods/burstable/podaf389229-5fc5-4617-ae95-9160d576eb49: cache:0KB rss:0KB rss_huge:0KB shmem:0KB mapped_file:0KB dirty:0KB writeback:0KB swap:0KB inactive_anon:0KB active_anon:0KB inactive_file:0KB active_file:0KB unevictable:0KB  # noqa: E501
 # [21013.577527] Memory cgroup stats for /kubepods/burstable/podaf389229-5fc5-4617-ae95-9160d576eb49/4c08772ec23ea2f82822e90f1d41c028b43eb01f0bfc18ea262ae4ccbc6189de: cache:0KB rss:36KB rss_huge:0KB shmem:0KB mapped_file:0KB dirty:0KB writeback:0KB swap:0KB inactive_anon:0KB active_anon:36KB inactive_file:0KB active_file:0KB unevictable:0KB  # noqa: E501
 # [21013.577527] Memory cgroup out of memory: Kill process 8308 (java) score 1894 or sacrifice child  # noqa: E501
-
-LOG = logging.getLogger(__name__)
-TIMESTAMP_RE = re.compile(r"\[\s*(\d+\.\d+)\].*")
 START_RE = re.compile(
     r"\[\s*(\d+\.\d+)\] Task in /kubepods/(?:burstable/)?pod([0-9a-f_-]*)/([0-9a-f]*) killed as a result of "
     r"limit of /kubepods/(?:burstable/)?pod[0-9a-f_-]*"
@@ -28,6 +28,10 @@ OOM_RE = re.compile(
     r"\[\s*(\d+\.\d+)\] Memory cgroup out of memory: Kill process \d+ \(([^)]+)\) score \d+ or "
     r"sacrifice child"
 )
+
+# Interesting messages in dmesg with new kernels:
+# [10657070.816698] oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=7a982186b58cec345c4a3f635809c7e04afc930453a5dbb5cbc9d4d49f662761,mems_allowed=0,oom_memcg=/kubepods/burstable/pod792adfde-d139-4c9c-a89e-ae94f36ea69d/7a982186b58cec345c4a3f635809c7e04afc930453a5dbb5cbc9d4d49f662761,task_memcg=/kubepods/burstable/pod792adfde-d139-4c9c-a89e-ae94f36ea69d/7a982186b58cec345c4a3f635809c7e04afc930453a5dbb5cbc9d4d49f662761,task=ruby,pid=10506,uid=1000  # noqa: E501
+OOM_KILL_RE = re.compile(r"\[\s*(\d+\.\d+)\] oom-kill:(.*)")
 
 
 class Dmesg(MessageReader):
@@ -44,49 +48,71 @@ class Dmesg(MessageReader):
             self._cur = Oom(self._node_name)
         return self._cur
 
-    def get_ooms(self, kube: Kubernetes) -> List[Oom]:
+    def _process_ooms(self, lines: Iterable[bytes], kube: Kubernetes) -> List[Oom]:
         ooms: List[Oom] = []
         pod_infos = None
+        for message in _get_messages(lines):
+            # Cannot use --follow (not working in a container) and cannot specify a position in the
+            # logs where to start. So, we need to read everything from the start and ignore the logs
+            # we've already seen.
+            timestamp_match = TIMESTAMP_RE.match(message)
+            if not timestamp_match:
+                continue
+            timestamp = float(timestamp_match.group(1))
+            if self._prev_timestamp is not None and self._prev_timestamp >= timestamp:
+                continue
+            self._prev_timestamp = timestamp
+
+            LOG.debug("message: <%s>", message)
+            start_match = START_RE.match(message)
+            pod_match = CONTAINER_RE.match(message)
+            oom_match = OOM_RE.match(message)
+            oom_kill_match = OOM_KILL_RE.match(message)
+            if start_match:
+                if pod_infos is None:
+                    pod_infos = kube.get_pod_infos()
+                self._get_cur().add_start_info(start_match, pod_infos)
+            elif pod_match:
+                self._get_cur().add_pod_info(pod_match)
+            elif oom_match:
+                if self._cur is not None and self._cur.add_oom_info(oom_match):
+                    ooms.append(self._cur)
+                self._cur = None
+            elif oom_kill_match:
+                fields = _split_oom_kill(oom_kill_match.group(2))
+                if pod_infos is None:
+                    pod_infos = kube.get_pod_infos()
+                if self._get_cur().add_oom_kill_info(fields, pod_infos):
+                    ooms.append(self._get_cur())
+                self._cur = None
+        return ooms
+
+    def get_ooms(self, kube: Kubernetes) -> List[Oom]:
         with subprocess.Popen(  # nosec
             ["/usr/bin/dmesg", "--facility=kern", "--level=info,err"], stdout=subprocess.PIPE
         ) as dmesg:
             if dmesg.stdout is None:
                 return []
-            prev = b""
-            timestamp = None
-            for line in dmesg.stdout:
-                line = prev + line
-                if not line.endswith(b"\n"):
-                    prev = line
-                else:
-                    prev = b""
-                    message = line.decode().rstrip("\n")
-
-                    # Cannot use --follow (not working in a container) and cannot specify a position in the
-                    # logs where to start. So, we need to read everything from the start and ignore the logs
-                    # we've already seen.
-                    timestamp_match = TIMESTAMP_RE.match(message)
-                    if not timestamp_match:
-                        continue
-                    timestamp = float(timestamp_match.group(1))
-                    if self._prev_timestamp is not None and self._prev_timestamp >= timestamp:
-                        continue
-
-                    LOG.debug("message: <%s>", message)
-                    start_match = START_RE.match(message)
-                    pod_match = CONTAINER_RE.match(message)
-                    oom_match = OOM_RE.match(message)
-                    if start_match:
-                        if pod_infos is None:
-                            pod_infos = kube.get_pod_infos()
-                        self._get_cur().add_start_info(start_match, pod_infos)
-                    elif pod_match:
-                        self._get_cur().add_pod_info(pod_match)
-                    elif oom_match:
-                        if self._cur is not None and self._cur.add_oom_info(oom_match):
-                            ooms.append(self._cur)
-                        self._cur = None
-            if timestamp is not None:
-                self._prev_timestamp = timestamp
+            ooms = self._process_ooms(dmesg.stdout, kube)
             dmesg.wait()
         return ooms
+
+
+def _get_messages(data: Iterable[bytes]) -> Iterable[str]:
+    prev = b""
+    for cur in data:
+        cur = prev + cur
+        if not cur.endswith(b"\n"):
+            prev = cur
+        else:
+            prev = b""
+            yield cur.decode().rstrip("\n")
+
+
+def _split_oom_kill(text: str) -> Dict[str, str]:
+    result: Dict[str, str] = {}
+    for field in text.split(","):
+        split_field = field.split("=", 1)
+        if len(split_field) == 2:
+            result[split_field[0]] = split_field[1]
+    return result

--- a/es_oom_exporter/kube.py
+++ b/es_oom_exporter/kube.py
@@ -43,16 +43,16 @@ class Kubernetes:
             status = pod.status
             containers = {}
             for statuses in (status.container_statuses, status.init_container_statuses):
-                if statuses is not None:
-                    for container_status in statuses:
-                        if container_status.container_id is not None:
-                            containers[
-                                container_status.container_id.replace("docker://", "")
-                            ] = container_status.name
-                        if container_status.last_state.terminated is not None:
-                            containers[
-                                container_status.last_state.terminated.container_id.replace("docker://", "")
-                            ] = container_status.name
+                if statuses is None:
+                    continue
+                for container_status in statuses:
+                    for location in (
+                        container_status,
+                        container_status.last_state.terminated,
+                        container_status.state.terminated,
+                    ):
+                        if location is not None and location.container_id is not None:
+                            containers[location.container_id.replace("docker://", "")] = container_status.name
             results[md.uid] = {
                 "namespace": md.namespace,
                 "release": md.labels.get("release", md.labels.get("app.kubernetes.io/instance")),

--- a/tests/test_dmesg.py
+++ b/tests/test_dmesg.py
@@ -1,0 +1,62 @@
+from mockito import mock, when
+
+from es_oom_exporter.dmesg import Dmesg
+
+
+def test_new_kernel(monkeypatch):
+    monkeypatch.setenv("NODE_NAME", "toto")
+    dmesg = Dmesg()
+    kube = mock()
+    when(kube).get_pod_infos().thenReturn(
+        {
+            "792adfde-d139-4c9c-a89e-ae94f36ea69d": {
+                "namespace": "my_ns",
+                "release": "my_release",
+                "service": "my_service",
+                "pod_name": "my_pod",
+                "containers": {
+                    "7a982186b58cec345c4a3f635809c7e04afc930453a5dbb5cbc9d4d49f662761": "my_container"
+                },
+            }
+        }
+    )
+
+    ooms = dmesg._process_ooms(
+        [
+            b"[10657070.816698] oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=7a982186b58cec345c4a3f635809c7e04afc930453a5dbb5cbc9d4d49f662761,mems_allowed=0,oom_memcg=/kubepods/burstable/pod792adfde-d139-4c9c-a89e-ae94f36ea69d/7a982186b58cec345c4a3f635809c7e04afc930453a5dbb5cbc9d4d49f662761,task_memcg=/kubepods/burstable/pod792adfde-d139-4c9c-a89e-ae94f36ea69d/7a982186b58cec345c4a3f635809c7e04afc930453a5dbb5cbc9d4d49f662761,task=ruby,pid=10506,uid=1000\n"  # noqa: E501
+        ],
+        kube,
+    )
+
+    assert list(map(repr, ooms)) == ["Oom(my_ns/my_pod/my_container/ruby/toto=None)"]
+
+
+def test_old_kernel(monkeypatch):
+    monkeypatch.setenv("NODE_NAME", "toto")
+    dmesg = Dmesg()
+    kube = mock()
+    when(kube).get_pod_infos().thenReturn(
+        {
+            "af389229-5fc5-4617-ae95-9160d576eb49": {
+                "namespace": "my_ns",
+                "release": "my_release",
+                "service": "my_service",
+                "pod_name": "my_pod",
+                "containers": {
+                    "3b3d031aca1bab63c359a8aac8c18e373ac90373faf12c69e5225aec01fc9c84": "my_container"
+                },
+            }
+        }
+    )
+
+    ooms = dmesg._process_ooms(
+        [
+            b"[21013.577527] Task in /kubepods/burstable/podaf389229-5fc5-4617-ae95-9160d576eb49/3b3d031aca1bab63c359a8aac8c18e373ac90373faf12c69e5225aec01fc9c84 killed as a result of limit of /kubepods/burstable/podaf389229-5fc5-4617-ae95-9160d576eb49\n",  # noqa: E501
+            b"[21013.577528] Memory cgroup stats for /kubepods/burstable/podaf389229-5fc5-4617-ae95-9160d576eb49: cache:0KB rss:0KB rss_huge:0KB shmem:0KB mapped_file:0KB dirty:0KB writeback:0KB swap:0KB inactive_anon:0KB active_anon:0KB inactive_file:0KB active_file:0KB unevictable:0KB\n",  # noqa: E501
+            b"[21013.577529] Memory cgroup stats for /kubepods/burstable/podaf389229-5fc5-4617-ae95-9160d576eb49/3b3d031aca1bab63c359a8aac8c18e373ac90373faf12c69e5225aec01fc9c84: cache:0KB rss:36KB rss_huge:0KB shmem:0KB mapped_file:0KB dirty:0KB writeback:0KB swap:0KB inactive_anon:0KB active_anon:36KB inactive_file:0KB active_file:0KB unevictable:0KB\n",  # noqa: E501
+            b"[21013.577530] Memory cgroup out of memory: Kill process 8308 (java) score 1894 or sacrifice child\n",  # noqa: E501
+        ],
+        kube,
+    )
+
+    assert list(map(repr, ooms)) == ["Oom(my_ns/my_pod/my_container/java/toto=36864)"]


### PR DESCRIPTION
Looks like EKS upgraded their kernel versions (5.4.156) and in those,
the OOM messages are totally different.
This adds support for that.

And the output of kubernetes is slightly changed around the status of
terminated containers. Adapted to that as well.

Still supports older kernels and kubernetes.